### PR TITLE
Update EmailTemplates.polish-utf8.php

### DIFF
--- a/smf_2-0_polish-utf8/Themes/default/languages/EmailTemplates.polish-utf8.php
+++ b/smf_2-0_polish-utf8/Themes/default/languages/EmailTemplates.polish-utf8.php
@@ -626,9 +626,9 @@ COMMENT: The comment left by the reporter, hopefully to explain why they are rep
 @description: When a user reports a post this email is sent out to moderators and admins of that board.
 */
 
-'subject' => 'Wiadomość zaraportowana : {TOPICSUBJECT} przez {POSTERNAME}',
+'subject' => 'Wiadomość zaraportowana: {TOPICSUBJECT} przez {POSTERNAME}',
 
-'body' => 'Następująca wiadomość, "{TOPICSUBJECT}" napisana przez {POSTERNAME} została zaraportowana przez {REPORTERNAME} na forum, które moderujesz:
+'body' => 'Następująca wiadomość: "{TOPICSUBJECT}" napisana przez {POSTERNAME} została zaraportowana przez {REPORTERNAME} na forum, które moderujesz:
 
 Temat: {TOPICLINK}
 Centrum moderacji: {REPORTLINK}


### PR DESCRIPTION
1. Usunąłem odstęp między słowem a dwukropkiem, który opisałem tutaj: 

http://www.smf.pl/index.php/topic,8723.msg64033.html#msg64033

W linii angielskiej nie ma tego odstępu: 'subject' => 'Reported post: {TOPICSUBJECT} by {POSTERNAME}',

2. Może w tym fragmencie spolszczenia wstawić dwukropek zamiast przecinka przed nazwą tematu "Testowy temat"? Albo w ogóle usunąć ten przecinek.

Przykład:

Następująca wiadomość: "Testowy temat" napisana przez smefek została zaraportowana przez smefek na forum, które moderujesz:

Następująca wiadomość "Testowy temat" napisana przez smefek została zaraportowana przez smefek na forum, które moderujesz:

Linia angielska w sumie ma wstawiony przecinek, ale może to jest przez przypadek przez błąd wstawiony ten przecinek, w naszym języku kompletnie nie pasuje ten przecinek. Ja proponuję wstawić dwukropek (wstawiłem go) lub w ogóle bez dwukropka zostawić. (Patrz na przykłady wyżej).

'body' => 'The following post, "{TOPICSUBJECT}" by {POSTERNAME} has been reported by {REPORTERNAME} on a board you moderate: