### PR TITLE
Update Install.polish-utf8.php

### DIFF
--- a/smf_2-0_polish-utf8/Themes/default/languages/Install.polish-utf8.php
+++ b/smf_2-0_polish-utf8/Themes/default/languages/Install.polish-utf8.php
@@ -87,7 +87,7 @@ $txt['error_message_try_again'] = 'aby wykonać ten krok ponownie.';
 $txt['error_message_bad_try_again'] = 'aby spróbować instalacji mimo wszystko. Miej jednak na uwadze, że jest to <em>mocno</em> odradzane.';
 
 $txt['install_settings'] = 'Podstawowe ustawienia';
-$txt['install_settings_info'] = 'Kilka prostych rzeczy, które musisz ustawić ;).';
+$txt['install_settings_info'] = 'Ta strona wymaga od ciebie podania kilku kluczowych ustawień dla twojego forum. SMF automatycznie wykryło kluczowe ustawienia dla ciebie.';
 $txt['install_settings_name'] = 'Nazwa forum';
 $txt['install_settings_name_info'] = 'To jest nazwa twojego forum, np. &quot;Forum testowe&quot;.';
 $txt['install_settings_name_default'] = 'Moje forum';
@@ -98,7 +98,7 @@ $txt['install_settings_compress_title'] = 'Pakuj dane aby zmniejszyć transfer';
 // In this string, you can translate the word "PASS" to change what it says when the test passes.
 $txt['install_settings_compress_info'] = 'Funkcja ta nie działa na niektórych serwerach, zmniejszy natomiast zarówno transfer danych na forum jak i rozmiar bazy danych.<br />Kliknij <a href="install.php?obgz=1&amp;pass_string=OK" onclick="return reqWin(this.href, 200, 60);">tutaj</a> aby ją przetestować (powinien pokazać się napis "OK").';
 $txt['install_settings_dbsession'] = 'Sesje w bazie danych';
-$txt['install_settings_dbsession_title'] = 'Użyj bazy danych zamiast plików do przechowania informacji o sesjach.';
+$txt['install_settings_dbsession_title'] = 'Użyj bazy danych zamiast plików do przechowania informacji o sesjach';
 $txt['install_settings_dbsession_info1'] = 'Najczęściej warto włączyć tę funkcję, ponieważ dzięki niej dane o sesjach są bardziej godne zaufania.';
 $txt['install_settings_dbsession_info2'] = 'Nie wygląda na to, że ta funkcja zadziała na Twoim serwerze ale możesz spróbować.';
 $txt['install_settings_utf8'] = 'Kodowanie UTF-8';


### PR DESCRIPTION
Zmieniłem tę jedną linię w instalacji "Kilka prostych rzeczy, które musisz ustawić ;)." w zasadzie trzymając się oryginału i bez dziecinnej emotki.

Usunąłem jedną kropkę na końcu zdania w tej instalacji, ponieważ w polskiej wersji była postawiona ta kropka tylko w tej linii, a inne linie nie miały kropek na końcu to są tak zwane zdania opisujące funkcje, a wersji angielskiej znowu jest inaczej, dwie linie mają kropki na końcu, a reszta nie ma. Więc albo w ogóle nie będzie kropek na końcu zdań tych linii albo trzeba wstawić wszędzie. To już zdecyduj.

Spójrz, tam gdzie zaznaczyłem czerwoną ramką tam była kropka: https://images91.fotosik.pl/98/803f0cd9f573a519.png
A tam gdzie są zielone ramki tam nie ma kropek. Więc nie pasuje tak, żeby jedna kropka kończyła TYLKO jedno zdanie funkcji. Albo wszędzie albo nigdzie. 

Spójrz jak to jest w angielskiej wersji: https://images91.fotosik.pl/98/412d110b4c041d4a.png